### PR TITLE
Override the password reset urls

### DIFF
--- a/teachdentistry/urls.py
+++ b/teachdentistry/urls.py
@@ -1,13 +1,17 @@
+import os.path
+
 from django.conf import settings
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
+from django.contrib.auth import views as auth_views
 from django.views.generic import TemplateView
 from registration.backends.default.views import RegistrationView
 from tastypie.api import Api
+
 from teachdentistry.main.api import DentalEducatorResource, InstitutionResource
 from teachdentistry.main.models import UserProfileForm
 from teachdentistry.main.views import ReportView
-import os.path
+
 
 v1_api = Api(api_name='v1')
 v1_api.register(DentalEducatorResource())
@@ -20,6 +24,20 @@ site_media_root = os.path.join(os.path.dirname(__file__), "../media")
 urlpatterns = patterns(
     '',
     ('^accounts/', include('djangowind.urls')),
+
+    url(r'^password/reset/$',
+        auth_views.password_reset,
+        name='password_reset'),
+    url(r'^password/reset/done/$',
+        auth_views.password_reset_done,
+        name='password_reset_done'),
+    url(r'^password/reset/complete/$',
+        auth_views.password_reset_complete,
+        name='password_reset_complete'),
+    url(r'^password/reset/confirm/(?P<uidb64>[0-9A-Za-z]+)-(?P<token>.+)/$',
+        auth_views.password_reset_confirm,
+        name='password_reset_confirm'),
+
     url(r'^accounts/register/$', RegistrationView.as_view(
         form_class=UserProfileForm),
         name='registration_register'),


### PR DESCRIPTION
The password reset functionality is broken due to some interaction between a django upgrade + django-registration. Override the urls to resolve.