### PR TITLE
remove tagging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,6 @@ rjsmin==1.0.12
 django-tastypie==0.12.2
 djangowind==0.14.1
 sorl==3.1
-tagging==0.3-pre
 typogrify==2.0.7
 django-indexer==0.3.0
 django-templatetag-sugar==1.0

--- a/teachdentistry/settings_shared.py
+++ b/teachdentistry/settings_shared.py
@@ -23,7 +23,6 @@ TEMPLATE_CONTEXT_PROCESSORS += [  # noqa
 
 INSTALLED_APPS += [  # noqa
     'sorl.thumbnail',
-    'tagging',
     'typogrify',
     'bootstrapform',
     'lettuce.django',


### PR DESCRIPTION
doesn't appear to be used, and not django 1.9 compatible