### PR TITLE
Use default from email address

### DIFF
--- a/teachdentistry/settings_shared.py
+++ b/teachdentistry/settings_shared.py
@@ -50,5 +50,3 @@ LETTUCE_APPS = (
 )
 
 THUMBNAIL_SUBDIR = "thumbs"
-
-DEFAULT_FROM_EMAIL = 'ccnmtl-teachdentistry@columbia.edu'


### PR DESCRIPTION
System generated emails (registration, password recovery, etc.) need to come from the *.ccnmtl.columbia.edu domain to get through SES validation.